### PR TITLE
Add products

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class ProductsController < ApplicationController
+  def index
+    @products = Product.all
+  end
+
+  def new
+    @product = Product.new
+  end
+
+  def edit
+    product
+  end
+
+  def create
+    @product = Product.find_or_initialize_by(product_attributes)
+
+    respond_to do |format|
+      if @product.save
+        format.html { redirect_to edit_product_path(@product) }
+      else
+        format.html { render :new }
+      end
+    end
+  end
+
+  def update
+    respond_to do |format|
+      if product.update(product_attributes)
+        format.html do
+          redirect_to edit_product_path(product), notice: "Product was successfully updated."
+        end
+      else
+        format.html { render :edit }
+      end
+    end
+  end
+
+  def destroy
+    respond_to do |format|
+      if product.destroy
+        format.html { redirect_to products_path, notice: "Product was successfully destroyed." }
+      end
+    end
+  end
+
+  private
+
+  def product
+    @product ||= Product.find(params[:id])
+  end
+
+  def product_attributes
+    params.require(:product).permit(:name, :code, :price)
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Product < ApplicationRecord
+  with_options presence: true do
+    validates :code, :name, :price
+    validates :price, numericality: { greater_than: 0 }
+  end
+end

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -1,0 +1,10 @@
+<%= form_with(model: @product) do |form| %>
+  <% %i(code name price).each do |name| %>
+    <%= render "shared/text_field", form:, name:, type: "text", errors: @product.errors[name] %>
+  <% end %>
+
+  <div class="pt-2">
+    <%= form.submit "Save", class: "btn btn-primary" %>
+    <%= link_to "Cancel", products_path, class: "btn btn-secondary" %>
+  </div>
+<% end %>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,0 +1,8 @@
+<tr>
+  <td><%= product.code %></td>
+  <td><%= product.name %></td>
+  <td><%= number_to_currency product.price, unit: "€" %></td>
+  <td class="d-flex justify-content-center">
+    <%= link_to "Edit", edit_product_path(product.id), class: "btn btn-sm btn-secondary mr-1" %>
+  </td>
+</tr>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -1,0 +1,17 @@
+<div class="ml-4">
+  <div class="row">
+    <div class="col-6">
+      <div class="row">
+        <div class="col-6">
+          <h1>Edit product: <%= @product.name %></h1>
+        </div>
+        <div class="col-6">
+          <%= button_to "Destroy", product_path(@product), method: :delete, class: "btn btn-danger mt-2" %>
+        </div>
+      </div>
+      <p style="color: green"><%= notice %></p>
+
+      <%= render "form" %>
+    </div>
+  </div>
+</div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,0 +1,22 @@
+<div class="ml-4">
+  <p style="color: green"><%= notice %></p>
+  <h1>Products</h1>
+
+  <div class="mb-5">
+    <table class="w-50">
+      <tr>
+        <th><strong>Code</strong></th>
+        <th><strong>Name</strong></th>
+        <th><strong>Price</strong></th>
+        <th class="text-center"><strong>Actions</strong></th>
+      </tr>
+      <% @products.each do |product| %>
+        <%= render product %>
+      <% end %>
+    </table>
+  </div>
+
+  <div class="d-inline-flex">
+    <%= link_to "New product", new_product_path, class: "btn btn-success mr-2" %>
+  </div>
+</div>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -1,0 +1,6 @@
+<div class="ml-4">
+  <h1>Add product</h1>
+  <p style="color: green"><%= notice %></p>
+
+  <%= render "form" %>
+</div>

--- a/app/views/shared/_text_field.html.erb
+++ b/app/views/shared/_text_field.html.erb
@@ -1,0 +1,9 @@
+<div>
+  <%= form.label name, style: "display: block" %>
+  <%= form.text_field name %>
+  <% if errors.any? %>
+    <% errors.each do |e| %>
+      <p style="color: red"><%= e %></p>
+    <% end %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  resources :products
+
+  root "products#index"
 end

--- a/db/migrate/20240723181300_create_products.rb
+++ b/db/migrate/20240723181300_create_products.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateProducts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :products do |t|
+      t.string :code, null: false
+      t.string :name, null: false
+      t.decimal :price, null: false, precision: 10, scale: 2
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_23_181300) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "products", force: :cascade do |t|
+    t.string "code", null: false
+    t.string "name", null: false
+    t.decimal "price", precision: 10, scale: 2, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,3 @@
+green_tea = Product.find_or_create_by!(name: "Green tea", code: "GR1", price: 3.11)
+strawberries = Product.find_or_create_by!(name: "Strawberries", code: "SR1", price: 5.00)
+coffee = Product.find_or_create_by!(name: "Coffee", code: "CF1", price: 11.23)

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ProductsControllerTest < ActionDispatch::IntegrationTest
+  test "index" do
+    product = create(:product)
+
+    get products_path
+    assert_response :success
+    assert_includes response.body, "<td>#{product.code}</td>\n  " \
+                                   "<td>#{product.name}</td>\n  " \
+                                   "<td>€#{product.price}</td>"
+  end
+
+  test "new" do
+    get new_product_path
+    assert_response :success
+  end
+
+  test "edit" do
+    product = create(:product)
+
+    get edit_product_path(product)
+    assert_response :success
+    assert_includes response.body, "<input type=\"text\" value=\"#{product.price}\" " \
+                                   "name=\"product[price]\" id=\"product_price\" />"
+    assert_includes response.body, "<h1>Edit product: #{product.name}</h1>"
+  end
+
+  test "create" do
+    product = build(:product).attributes
+
+    assert_difference -> { Product.count }, +1 do
+      post products_path, params: { product: }
+    end
+
+    assert_redirected_to edit_product_path(Product.last.id)
+  end
+
+  test "update" do
+    product = create(:product)
+    new_code = "PR-123"
+
+    put product_path(product), params: { product: { code: new_code } }
+
+    product.reload
+    assert product.code, new_code
+    assert_redirected_to edit_product_path(product)
+  end
+
+  test "destroy" do
+    product = create(:product)
+
+    assert_difference -> { Product.count }, -1 do
+      delete product_path(product)
+    end
+
+    assert_redirected_to products_path
+  end
+end

--- a/test/factories/products.rb
+++ b/test/factories/products.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :product do
+    code { "PR-#{random_chars} " }
+    name { "My product #{random_chars}" }
+    price { 1.23 }
+  end
+end
+
+def random_chars
+  @random_chars ||= SecureRandom.hex(3)
+end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ProductTest < ActiveSupport::TestCase
+  test "invalid when required attributes are missing" do
+    product = build(:product, code: nil, name: nil, price: nil)
+
+    assert product.invalid?
+
+    %i(code name price).each do |field|
+      assert product.errors.added?(field, :blank)
+    end
+  end
+
+  test "invalid when price is not a number" do
+    invalid_price = "invalid"
+    product = build(:product, price: invalid_price)
+
+    assert product.invalid?
+    assert product.errors.added?(:price, :not_a_number, value: invalid_price)
+  end
+
+  test "valid product" do
+    product = build(:product)
+    assert product.valid?
+  end
+end


### PR DESCRIPTION
Adding `Product` model with basic validation, controller, seeds. 

`Product.find_or_initialize_by(product_attributes)` in order to avoid duplicates.
`shared/text_field` partial to reduce boilerplate a tiny bit. This way we have error messages next to the field with errors.
