### PR TITLE
Add pricing rules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,5 +21,6 @@ group :development, :test do
   gem "factory_bot_rails", "~> 6.4.3"
   gem "minitest", "~> 5.22.2"
   gem "minitest-profile"
+  gem "rails-controller-testing", "~> 1.0"
   gem "webmock", "~> 3.23.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,10 @@ GEM
       activesupport (= 7.0.8.4)
       bundler (>= 1.15.0)
       railties (= 7.0.8.4)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -266,6 +270,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.8, >= 7.0.8.4)
+  rails-controller-testing (~> 1.0)
   rubocop (~> 1.64)
   rubocop-rails (~> 2.25)
   solargraph (~> 0.50.0)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Shopping cart app
+
+## Setting up the environment
+1. Get Ruby `3.3.3`
+2. `bundle install`
+3. `rails db:create && rails db:migrate && rails db:seed`
+
+## Pricing rules
+
+Each product can have zero or more pricing rules.
+
+`PricingRule` attributes
+- `discount_type` - type of discount based on which we calculate the product group price.
+- `discount_amount` - amount of discount in cash/percent, depending on `discount_type`. Always greater than `0`.
+- `min_amount` - minimum product quantity from which the discount is applied. Greater than or equal to `0` (we may want to discount the product regardless of its amount)
+- `status` - status of the rule `active | inactive`. Each product can have exactly `1` active pricing rule.
+
+There are 3 `discount_type`s to choose from for the `PricingRule`:
+- `buy_one_get_one_free` - every other product is free of charge. `min_amount` and `discount_amount` are not taken into account during the calculation
+- `price` - price discount on every product
+- `percentage` - percentage discount on every product

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Each product can have zero or more pricing rules.
 `PricingRule` attributes
 - `discount_type` - type of discount based on which we calculate the product group price.
 - `discount_amount` - amount of discount in cash/percent, depending on `discount_type`. Always greater than `0`.
-- `min_amount` - minimum product quantity from which the discount is applied. Greater than or equal to `0` (we may want to discount the product regardless of its amount)
+- `min_quantity` - minimum product quantity from which the discount is applied. Greater than or equal to `0` (we may want to discount the product regardless of its amount)
 - `status` - status of the rule `active | inactive`. Each product can have exactly `1` active pricing rule.
 
 There are 3 `discount_type`s to choose from for the `PricingRule`:
-- `buy_one_get_one_free` - every other product is free of charge. `min_amount` and `discount_amount` are not taken into account during the calculation
+- `buy_one_get_one_free` - every other product is free of charge. `min_quantity` and `discount_amount` are not taken into account during the calculation
 - `price` - price discount on every product
 - `percentage` - percentage discount on every product

--- a/app/controllers/pricing_rules_controller.rb
+++ b/app/controllers/pricing_rules_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class PricingRulesController < ApplicationController
+  def new
+    @pricing_rule = PricingRule.new
+  end
+
+  def edit
+    pricing_rule
+  end
+
+  def create # rubocop:disable Metrics/AbcSize
+    @pricing_rule = PricingRule.find_or_initialize_by(pricing_rule_attributes.except(:status))
+    @pricing_rule.status = pricing_rule_attributes.fetch(:status) unless @pricing_rule.persisted?
+
+    respond_to do |format|
+      if @pricing_rule.save
+        format.html { redirect_to edit_product_path(@pricing_rule.product) }
+      else
+        format.html { render :new }
+      end
+    end
+  end
+
+  def update
+    respond_to do |format|
+      if pricing_rule.update(pricing_rule_attributes)
+        format.html do
+          redirect_to edit_product_path(pricing_rule.product),
+                      notice: "Pricing rule was successfully updated."
+        end
+      else
+        format.html { render :edit }
+      end
+    end
+  end
+
+  def destroy
+    product = pricing_rule.product
+    respond_to do |format|
+      if pricing_rule.destroy
+        format.html do
+          redirect_to edit_product_path(product),
+                      notice: "Pricing rule was successfully destroyed."
+        end
+      end
+    end
+  end
+
+  private
+
+  def pricing_rule
+    @pricing_rule ||= PricingRule.find(params[:id])
+  end
+
+  def pricing_rule_attributes
+    params.require(:pricing_rule).permit(:discount_type, :discount_amount,
+                                         :status, :min_amount, :product_id)
+  end
+end

--- a/app/controllers/pricing_rules_controller.rb
+++ b/app/controllers/pricing_rules_controller.rb
@@ -55,6 +55,6 @@ class PricingRulesController < ApplicationController
 
   def pricing_rule_attributes
     params.require(:pricing_rule).permit(:discount_type, :discount_amount,
-                                         :status, :min_amount, :product_id)
+                                         :status, :min_quantity, :product_id)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,8 +3,6 @@
 module ApplicationHelper
   def discount_amount(pricing_rule)
     case pricing_rule.discount_type
-    when PricingRule::BUY_ONE_GET_ONE_FREE_DISCOUNT
-      "n/a"
     when PricingRule::PERCENTAGE_DISCOUNT
       "#{pricing_rule.discount_amount}%"
     when PricingRule::PRICE_DISCOUNT
@@ -19,7 +17,7 @@ module ApplicationHelper
     when PricingRule::BUY_ONE_GET_ONE_FREE_DISCOUNT
       "n/a"
     else
-      pricing_rule.min_amount
+      pricing_rule.min_quantity
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ApplicationHelper
+  def discount_amount(pricing_rule)
+    case pricing_rule.discount_type
+    when PricingRule::BUY_ONE_GET_ONE_FREE_DISCOUNT
+      "n/a"
+    when PricingRule::PERCENTAGE_DISCOUNT
+      "#{pricing_rule.discount_amount}%"
+    when PricingRule::PRICE_DISCOUNT
+      "#{pricing_rule.discount_amount}€"
+    else
+      "n/a"
+    end
+  end
+
+  def minimum_amount(pricing_rule)
+    case pricing_rule.discount_type
+    when PricingRule::BUY_ONE_GET_ONE_FREE_DISCOUNT
+      "n/a"
+    else
+      pricing_rule.min_amount
+    end
+  end
+end

--- a/app/models/pricing_rule.rb
+++ b/app/models/pricing_rule.rb
@@ -23,7 +23,7 @@ class PricingRule < ApplicationRecord
   end
 
   with_options presence: true, unless: :buy_one_get_one_free? do
-    validates :min_amount, numericality: { greater_than_or_equal: 0 }
+    validates :min_quantity, numericality: { greater_than_or_equal: 0 }
     validates :discount_amount, numericality: { greater_than: 0 }
   end
 
@@ -50,7 +50,7 @@ class PricingRule < ApplicationRecord
   def clear_amounts
     return unless buy_one_get_one_free?
 
-    self.min_amount = 0
+    self.min_quantity = 0
     self.discount_amount = 0
   end
 end

--- a/app/models/pricing_rule.rb
+++ b/app/models/pricing_rule.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class PricingRule < ApplicationRecord
+  STATUSES = [
+    ACTIVE_STATUS = "active",
+    INACTIVE_STATUS = "inactive"
+  ].freeze
+
+  DISCOUNT_TYPES = [
+    BUY_ONE_GET_ONE_FREE_DISCOUNT = "buy_one_get_one_free",
+    PERCENTAGE_DISCOUNT = "percentage",
+    PRICE_DISCOUNT = "price"
+  ].freeze
+
+  belongs_to :product
+
+  validate :validate_status, on: %i(create update), if: -> { product.present? }
+
+  with_options presence: true do
+    validates :product
+    validates :discount_type, inclusion: { in: DISCOUNT_TYPES }
+    validates :status, inclusion: { in: STATUSES }
+  end
+
+  with_options presence: true, unless: :buy_one_get_one_free? do
+    validates :min_amount, numericality: { greater_than_or_equal: 0 }
+    validates :discount_amount, numericality: { greater_than: 0 }
+  end
+
+  # No point to have more than one discount of this type
+  validates :discount_type, uniqueness: { scope: :product_id }, if: :buy_one_get_one_free?
+
+  before_save :clear_amounts
+
+  def buy_one_get_one_free?
+    discount_type == BUY_ONE_GET_ONE_FREE_DISCOUNT
+  end
+
+  private
+
+  def validate_status
+    return true if status == INACTIVE_STATUS
+
+    active_pricing_rule = product.active_pricing_rule
+    return true if active_pricing_rule.blank? || active_pricing_rule == self
+
+    errors.add :status, "Only 1 active pricing rule per product allowed"
+  end
+
+  def clear_amounts
+    return unless buy_one_get_one_free?
+
+    self.min_amount = 0
+    self.discount_amount = 0
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 class Product < ApplicationRecord
+  # rubocop:disable Rails/HasManyOrHasOneDependent, Rails/InverseOf
+  has_one :active_pricing_rule,
+          -> { PricingRule.where(status: PricingRule::ACTIVE_STATUS) },
+          class_name: "PricingRule"
+  has_many :pricing_rules, dependent: :delete_all
+  # rubocop:enable Rails/HasManyOrHasOneDependent, Rails/InverseOf
+
   with_options presence: true do
     validates :code, :name, :price
     validates :price, numericality: { greater_than: 0 }

--- a/app/views/pricing_rules/_form.html.erb
+++ b/app/views/pricing_rules/_form.html.erb
@@ -13,7 +13,7 @@
     <p style="color: red"><%= @pricing_rule.errors[:status].join("\n") %></p>
   </div>
 
-  <% %i(min_amount discount_amount).each do |name| %>
+  <% %i(min_quantity discount_amount).each do |name| %>
     <%= render "shared/text_field", form:, name:, type: "text", errors: @pricing_rule.errors[name] %>
   <% end %>
 

--- a/app/views/pricing_rules/_form.html.erb
+++ b/app/views/pricing_rules/_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_with(model: @pricing_rule) do |form| %>
+  <%= form.hidden_field :product_id, value: params[:product_id] || @pricing_rule.product.id %>
+
+  <div>
+    <%= form.label :discount_type, style: "display: block" %>
+    <%= form.select :discount_type, PricingRule::DISCOUNT_TYPES %>
+    <p style="color: red"><%= @pricing_rule.errors[:discount_type].join("\n") %></p>
+  </div>
+
+  <div>
+    <%= form.label :status, style: "display: block" %>
+    <%= form.select :status, PricingRule::STATUSES %>
+    <p style="color: red"><%= @pricing_rule.errors[:status].join("\n") %></p>
+  </div>
+
+  <% %i(min_amount discount_amount).each do |name| %>
+    <%= render "shared/text_field", form:, name:, type: "text", errors: @pricing_rule.errors[name] %>
+  <% end %>
+
+  <div class="pt-2">
+    <%= form.submit "Save", class: "btn btn-primary" %>
+    <%= link_to "Cancel", edit_product_path(@pricing_rule.product || params[:product_id]), class: "btn btn-secondary" %>
+  </div>
+<% end %>

--- a/app/views/pricing_rules/edit.html.erb
+++ b/app/views/pricing_rules/edit.html.erb
@@ -3,20 +3,15 @@
     <div class="col-6">
       <div class="row">
         <div class="col-6">
-          <h1>Edit product: <%= @product.name %></h1>
+          <h1>Edit pricing rule: <%= @pricing_rule.product.name %></h1>
         </div>
         <div class="col-6">
-          <%= button_to "Destroy", product_path(@product), method: :delete, class: "btn btn-danger mt-2 mr-2 float-right" %>
+          <%= button_to "Destroy", pricing_rule_path(@pricing_rule), method: :delete, class: "btn btn-danger mt-2" %>
         </div>
       </div>
-      <hr/>
       <p style="color: green"><%= notice %></p>
 
       <%= render "form" %>
-    </div>
-
-    <div class="col-6">
-      <%= render "pricing_rules", product: @product %>
     </div>
   </div>
 </div>

--- a/app/views/pricing_rules/new.html.erb
+++ b/app/views/pricing_rules/new.html.erb
@@ -1,0 +1,14 @@
+<div class="ml-4">
+  <div class="row">
+    <div class="col-6">
+      <div class="row">
+        <div class="col-6">
+          <h1>New pricing rule</h1>
+        </div>
+      </div>
+      <p style="color: green"><%= notice %></p>
+
+      <%= render "form" %>
+    </div>
+  </div>
+</div>

--- a/app/views/products/_pricing_rule.html.erb
+++ b/app/views/products/_pricing_rule.html.erb
@@ -1,0 +1,9 @@
+<tr>
+  <td><%= pricing_rule.discount_type %></td>
+  <td><%= minimum_amount(pricing_rule) %></td>
+  <td><%= discount_amount(pricing_rule) %></td>
+  <td><%= pricing_rule.status %></td>
+  <td class="d-flex justify-content-center">
+    <%= link_to "Edit", edit_pricing_rule_path(pricing_rule), class: "btn btn-sm btn-secondary" %>
+  </td>
+</tr>

--- a/app/views/products/_pricing_rules.html.erb
+++ b/app/views/products/_pricing_rules.html.erb
@@ -10,7 +10,7 @@
 <table class="w-100">
   <tr>
         <th><strong>Discount type</strong></th>
-        <th><strong>Minimum item amount</strong></th>
+        <th><strong>Minimum item quantity</strong></th>
         <th><strong>Discount amount</strong></th>
         <th><strong>Status</strong></th>
         <th class="text-center"><strong>Actions</strong></th>

--- a/app/views/products/_pricing_rules.html.erb
+++ b/app/views/products/_pricing_rules.html.erb
@@ -1,0 +1,21 @@
+<div class="row">
+  <div class="col-6">
+    <h1>Pricing rules</h1>
+  </div>
+  <div class="col-6">
+    <%= link_to "Add new", new_pricing_rule_path(@product), class: "btn btn-success mt-2 mr-2 float-right" %>
+  </div>
+</div>
+<hr/>
+<table class="w-100">
+  <tr>
+        <th><strong>Discount type</strong></th>
+        <th><strong>Minimum item amount</strong></th>
+        <th><strong>Discount amount</strong></th>
+        <th><strong>Status</strong></th>
+        <th class="text-center"><strong>Actions</strong></th>
+  </tr>
+  <% product.pricing_rules.each do |pricing_rule| %>
+    <%= render "pricing_rule", pricing_rule: %>
+  <% end %>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,7 @@
 Rails.application.routes.draw do
   resources :pricing_rules, except: %i(new)
   get "pricing_rules/:product_id/new", to: "pricing_rules#new", as: :new_pricing_rule
-  post "pricing_rules/activate", to: "pricing_rules#activate", as: :activate_pricing_rule
-  post "pricing_rules/deactivate", to: "pricing_rules#deactivate", as: :deactivate_pricing_rule
+
   resources :products
 
   root "products#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  resources :pricing_rules, except: %i(new)
+  get "pricing_rules/:product_id/new", to: "pricing_rules#new", as: :new_pricing_rule
+  post "pricing_rules/activate", to: "pricing_rules#activate", as: :activate_pricing_rule
+  post "pricing_rules/deactivate", to: "pricing_rules#deactivate", as: :deactivate_pricing_rule
   resources :products
 
   root "products#index"

--- a/db/migrate/20240723201303_create_pricing_rules.rb
+++ b/db/migrate/20240723201303_create_pricing_rules.rb
@@ -4,7 +4,7 @@ class CreatePricingRules < ActiveRecord::Migration[7.0]
   def change
     create_table :pricing_rules do |t|
       t.string :discount_type, null: false
-      t.integer :min_amount, null: false, default: 0
+      t.integer :min_quantity, null: false, default: 0
       t.decimal :discount_amount, null: false, precision: 5, scale: 2
       t.string :status, null: false
       t.belongs_to :product, null: false, foreign_key: true

--- a/db/migrate/20240723201303_create_pricing_rules.rb
+++ b/db/migrate/20240723201303_create_pricing_rules.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreatePricingRules < ActiveRecord::Migration[7.0]
+  def change
+    create_table :pricing_rules do |t|
+      t.string :discount_type, null: false
+      t.integer :min_amount, null: false, default: 0
+      t.decimal :discount_amount, null: false, precision: 5, scale: 2
+      t.string :status, null: false
+      t.belongs_to :product, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_23_181300) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_24_181300) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "pricing_rules", force: :cascade do |t|
+    t.string "discount_type", null: false
+    t.integer "min_amount", default: 0, null: false
+    t.decimal "discount_amount", precision: 5, scale: 2
+    t.string "status", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_pricing_rules_on_product_id"
+  end
 
   create_table "products", force: :cascade do |t|
     t.string "code", null: false
@@ -22,4 +33,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_23_181300) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "pricing_rules", "products"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_24_181300) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_23_201303) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "pricing_rules", force: :cascade do |t|
     t.string "discount_type", null: false
-    t.integer "min_amount", default: 0, null: false
-    t.decimal "discount_amount", precision: 5, scale: 2
+    t.integer "min_quantity", default: 0, null: false
+    t.decimal "discount_amount", precision: 5, scale: 2, null: false
     t.string "status", null: false
     t.bigint "product_id", null: false
     t.datetime "created_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,23 @@
 green_tea = Product.find_or_create_by!(name: "Green tea", code: "GR1", price: 3.11)
 strawberries = Product.find_or_create_by!(name: "Strawberries", code: "SR1", price: 5.00)
 coffee = Product.find_or_create_by!(name: "Coffee", code: "CF1", price: 11.23)
+
+PricingRule.find_or_create_by!(
+  discount_type: PricingRule::BUY_ONE_GET_ONE_FREE_DISCOUNT,
+  status: PricingRule::ACTIVE_STATUS,
+  product: green_tea
+) # in this case min_amount and discount_amount are ignored
+PricingRule.find_or_create_by!(
+  discount_type: PricingRule::PRICE_DISCOUNT,
+  min_amount: 3,
+  discount_amount: 0.5,
+  status: PricingRule::ACTIVE_STATUS,
+  product: strawberries
+)
+PricingRule.find_or_create_by!(
+  discount_type: PricingRule::PERCENTAGE_DISCOUNT,
+  min_amount: 3,
+  discount_amount: 0.33,
+  status: PricingRule::ACTIVE_STATUS,
+  product: coffee
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,17 +6,17 @@ PricingRule.find_or_create_by!(
   discount_type: PricingRule::BUY_ONE_GET_ONE_FREE_DISCOUNT,
   status: PricingRule::ACTIVE_STATUS,
   product: green_tea
-) # in this case min_amount and discount_amount are ignored
+) # in this case min_quantity and discount_amount are ignored
 PricingRule.find_or_create_by!(
   discount_type: PricingRule::PRICE_DISCOUNT,
-  min_amount: 3,
+  min_quantity: 3,
   discount_amount: 0.5,
   status: PricingRule::ACTIVE_STATUS,
   product: strawberries
 )
 PricingRule.find_or_create_by!(
   discount_type: PricingRule::PERCENTAGE_DISCOUNT,
-  min_amount: 3,
+  min_quantity: 3,
   discount_amount: 0.33,
   status: PricingRule::ACTIVE_STATUS,
   product: coffee

--- a/test/controllers/pricing_rules_controller_test.rb
+++ b/test/controllers/pricing_rules_controller_test.rb
@@ -18,8 +18,8 @@ class PricingRulesControllerTest < ActionDispatch::IntegrationTest
                                    "type=\"hidden\" name=\"pricing_rule[product_id]\" " \
                                    "id=\"pricing_rule_product_id\" />"
     assert_includes response.body, "<h1>Edit pricing rule: #{pricing_rule.product.name}</h1>"
-    assert_includes response.body, "<input type=\"text\" value=\"#{pricing_rule.min_amount}\" " \
-                                   "name=\"pricing_rule[min_amount]\" id=\"pricing_rule_min_amount\" />"
+    assert_includes response.body, "<input type=\"text\" value=\"#{pricing_rule.min_quantity}\" " \
+                                   "name=\"pricing_rule[min_quantity]\" id=\"pricing_rule_min_quantity\" />"
   end
 
   test "create" do
@@ -46,16 +46,38 @@ class PricingRulesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to edit_product_path(product.id)
   end
 
+  test "create fails" do
+    product = create(:product)
+    pricing_rule = { min_quantity: nil, discount_amount: nil, status: "invalid",
+                     discount_type: "invalid", product_id: product.id, }
+
+    assert_no_difference -> { product.pricing_rules.count } do
+      post pricing_rules_path, params: { pricing_rule: }
+    end
+
+    assert_template :new
+  end
+
   test "update" do
     product = create(:product)
     pricing_rule = create(:pricing_rule, :percentage_discount, product:)
-    new_min_amount = 5
+    new_min_quantity = 5
 
-    put pricing_rule_path(pricing_rule), params: { pricing_rule: { min_amount: new_min_amount } }
+    put pricing_rule_path(pricing_rule),
+        params: { pricing_rule: { min_quantity: new_min_quantity } }
 
     pricing_rule.reload
-    assert pricing_rule.min_amount, new_min_amount
+    assert pricing_rule.min_quantity, new_min_quantity
     assert_redirected_to edit_product_path(product)
+  end
+
+  test "update fails" do
+    product = create(:product)
+    pricing_rule = create(:pricing_rule, :percentage_discount, product:)
+
+    put pricing_rule_path(pricing_rule), params: { pricing_rule: { min_quantity: nil } }
+
+    assert_template :edit
   end
 
   test "destroy" do

--- a/test/controllers/pricing_rules_controller_test.rb
+++ b/test/controllers/pricing_rules_controller_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PricingRulesControllerTest < ActionDispatch::IntegrationTest
+  test "new" do
+    product = create(:product)
+    get new_pricing_rule_path(product_id: product.id)
+    assert_response :success
+  end
+
+  test "edit" do
+    pricing_rule = create(:pricing_rule, :price_discount)
+
+    get edit_pricing_rule_path(pricing_rule)
+    assert_response :success
+    assert_includes response.body, "<input value=\"#{pricing_rule.product.id}\" autocomplete=\"off\" " \
+                                   "type=\"hidden\" name=\"pricing_rule[product_id]\" " \
+                                   "id=\"pricing_rule_product_id\" />"
+    assert_includes response.body, "<h1>Edit pricing rule: #{pricing_rule.product.name}</h1>"
+    assert_includes response.body, "<input type=\"text\" value=\"#{pricing_rule.min_amount}\" " \
+                                   "name=\"pricing_rule[min_amount]\" id=\"pricing_rule_min_amount\" />"
+  end
+
+  test "create" do
+    product = create(:product)
+    pricing_rule = build(:pricing_rule, :percentage_discount, product:).attributes
+
+    assert_difference -> { product.pricing_rules.count }, +1 do
+      post pricing_rules_path, params: { pricing_rule: }
+    end
+
+    assert_redirected_to edit_product_path(product.id)
+  end
+
+  test "create without duplicates" do
+    product = create(:product)
+    pricing_rule = build(:pricing_rule, :percentage_discount, product:).attributes
+
+    assert_difference -> { product.pricing_rules.count }, +1 do
+      2.times do
+        post pricing_rules_path, params: { pricing_rule: }
+      end
+    end
+
+    assert_redirected_to edit_product_path(product.id)
+  end
+
+  test "update" do
+    product = create(:product)
+    pricing_rule = create(:pricing_rule, :percentage_discount, product:)
+    new_min_amount = 5
+
+    put pricing_rule_path(pricing_rule), params: { pricing_rule: { min_amount: new_min_amount } }
+
+    pricing_rule.reload
+    assert pricing_rule.min_amount, new_min_amount
+    assert_redirected_to edit_product_path(product)
+  end
+
+  test "destroy" do
+    product = create(:product)
+    pricing_rule = create(:pricing_rule, :percentage_discount, product:)
+
+    assert_difference -> { product.pricing_rules.count }, -1 do
+      delete pricing_rule_path(pricing_rule)
+    end
+
+    assert_redirected_to edit_product_path(product)
+  end
+end

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -38,6 +38,16 @@ class ProductsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to edit_product_path(Product.last.id)
   end
 
+  test "create fails" do
+    product = build(:product).attributes.merge(code: nil)
+
+    assert_no_difference -> { Product.count } do
+      post products_path, params: { product: }
+    end
+
+    assert_template :new
+  end
+
   test "update" do
     product = create(:product)
     new_code = "PR-123"
@@ -47,6 +57,14 @@ class ProductsControllerTest < ActionDispatch::IntegrationTest
     product.reload
     assert product.code, new_code
     assert_redirected_to edit_product_path(product)
+  end
+
+  test "update fails" do
+    product = create(:product)
+
+    put product_path(product), params: { product: { code: nil } }
+
+    assert_template :edit
   end
 
   test "destroy" do

--- a/test/factories/pricing_rules.rb
+++ b/test/factories/pricing_rules.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :pricing_rule do
     trait :price_discount do
       discount_type { PricingRule::PRICE_DISCOUNT }
-      min_amount { 2 }
+      min_quantity { 2 }
       discount_amount { 0.5 }
       status { PricingRule::ACTIVE_STATUS }
       product { create(:product) }
@@ -12,7 +12,7 @@ FactoryBot.define do
 
     trait :percentage_discount do
       discount_type { PricingRule::PERCENTAGE_DISCOUNT }
-      min_amount { 2 }
+      min_quantity { 2 }
       discount_amount { 0.5 }
       status { PricingRule::ACTIVE_STATUS }
       product { create(:product) }

--- a/test/factories/pricing_rules.rb
+++ b/test/factories/pricing_rules.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :pricing_rule do
+    trait :price_discount do
+      discount_type { PricingRule::PRICE_DISCOUNT }
+      min_amount { 2 }
+      discount_amount { 0.5 }
+      status { PricingRule::ACTIVE_STATUS }
+      product { create(:product) }
+    end
+
+    trait :percentage_discount do
+      discount_type { PricingRule::PERCENTAGE_DISCOUNT }
+      min_amount { 2 }
+      discount_amount { 0.5 }
+      status { PricingRule::ACTIVE_STATUS }
+      product { create(:product) }
+    end
+
+    trait :buy_one_get_one_free_discount do
+      discount_type { PricingRule::BUY_ONE_GET_ONE_FREE_DISCOUNT }
+      status { PricingRule::ACTIVE_STATUS }
+      product { create(:product) }
+    end
+  end
+end

--- a/test/models/pricing_rule_test.rb
+++ b/test/models/pricing_rule_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PricingRuleTest < ActiveSupport::TestCase
+  test "required fields" do
+    pricing_rule = build(:pricing_rule, :price_discount,
+                         discount_type: nil, status: nil, min_amount: nil, discount_amount: nil)
+
+    assert pricing_rule.invalid?
+
+    %i(discount_type discount_amount status min_amount).each do |field|
+      assert pricing_rule.errors.added?(field, :blank)
+    end
+  end
+
+  test "invalid when status is not valid" do
+    invalid_status = "invalid"
+    pricing_rule = build(:pricing_rule, :price_discount, status: invalid_status)
+
+    assert pricing_rule.invalid?
+    assert pricing_rule.errors.added?(:status, :inclusion, value: invalid_status)
+  end
+
+  test "invalid when discount_type is not valid" do
+    invalid_discount_type = "invalid"
+    pricing_rule = build(:pricing_rule, :price_discount, discount_type: invalid_discount_type)
+
+    assert pricing_rule.invalid?
+    assert pricing_rule.errors.added?(:discount_type, :inclusion, value: invalid_discount_type)
+  end
+
+  test "invalid without a product" do
+    pricing_rule = build(:pricing_rule, :buy_one_get_one_free_discount, product: nil)
+
+    assert pricing_rule.invalid?
+    assert pricing_rule.errors.added?(:product, :blank)
+  end
+
+  test "amounts are not required if buy_one_get_one_free?" do
+    pricing_rule = build(:pricing_rule, :buy_one_get_one_free_discount,
+                         min_amount: nil, discount_amount: nil)
+
+    assert pricing_rule.buy_one_get_one_free?
+    assert pricing_rule.valid?
+  end
+
+  test "only 1 active pricing rule allowed" do
+    product = create(:product)
+    create(:pricing_rule, :price_discount, product:)
+    product.reload
+    second_pricing_rule = build(:pricing_rule, :price_discount, product:)
+
+    assert second_pricing_rule.invalid?
+    assert second_pricing_rule.errors.added?(:status,
+                                             "Only 1 active pricing rule per product allowed")
+  end
+
+  test "only 1 buy_one_get_one_free allowed" do
+    product = create(:product)
+    create(:pricing_rule, :buy_one_get_one_free_discount, product:)
+    invalid_pricing_rule = build(:pricing_rule, :buy_one_get_one_free_discount, product:)
+    assert invalid_pricing_rule.invalid?
+    assert invalid_pricing_rule.errors.added?(:discount_type, :taken, value: "buy_one_get_one_free")
+  end
+
+  test "valid pricing rules" do
+    %i(buy_one_get_one_free_discount price_discount percentage_discount).each do |discount_type|
+      rule = build(:pricing_rule, discount_type)
+
+      assert rule.valid?
+    end
+  end
+end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -21,6 +21,14 @@ class ProductTest < ActiveSupport::TestCase
     assert product.errors.added?(:price, :not_a_number, value: invalid_price)
   end
 
+  test "has an active_pricing_rule" do
+    product = create(:product)
+    pricing_rule = create(:pricing_rule, :price_discount, product:)
+    product.reload
+
+    assert_equal product.active_pricing_rule, pricing_rule
+  end
+
   test "valid product" do
     product = build(:product)
     assert product.valid?


### PR DESCRIPTION
`PricingRule` attributes
- `discount_type` - type of discount based on which we calculate the product group price.
- `discount_amount` - amount of discount in cash/percent, depending on `discount_type`. Always greater than `0`.
- `min_amount` - minimum product quantity from which the discount is applied. Greater than or equal to `0` (we may want to discount the product regardless of its amount)
- `status` - status of the rule `active | inactive`. Each product can have exactly `1` active pricing rule.

There are 3 `discount_type`s to choose from for the `PricingRule`:
- `buy_one_get_one_free` - every other product is free of charge. `min_amount` and `discount_amount` are not taken into account during the calculation
- `price` - price discount on every product
- `percentage` - percentage discount on every product

Again, to avoid duplicates
```ruby
@pricing_rule = PricingRule.find_or_initialize_by(pricing_rule_attributes.except(:status))
@pricing_rule.status = pricing_rule_attributes.fetch(:status) unless @pricing_rule.persisted?
```

